### PR TITLE
default _separator for file list

### DIFF
--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -72,7 +72,7 @@ class Archive_Tar extends PEAR
     /**
     * @var string Explode separator
     */
-    var $_separator=' ';
+    var $_separator='|';
 
     /**
     * @var file descriptor


### PR DESCRIPTION
I think using `space` as default separator for `$_separator` is not a good idea because sometimes we have `space` in filenames and if developer does not set the `_separator` then the file will be ignored.
