### PR TITLE
Prevent extracting folder if it matches $p_remove_path

### DIFF
--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -1599,10 +1599,14 @@ class Archive_Tar extends PEAR
       if (($v_extract_file) && (!$v_listing))
       {
         if (($p_remove_path != '')
-            && (substr($v_header['filename'], 0, $p_remove_path_size)
-			    == $p_remove_path))
+            && (substr($v_header['filename'].'/', 0, $p_remove_path_size)
+			    == $p_remove_path)) {
           $v_header['filename'] = substr($v_header['filename'],
 		                                 $p_remove_path_size);
+          if( $v_header['filename'] == '' ){
+            continue;
+          }
+        }
         if (($p_path != './') && ($p_path != '/')) {
           while (substr($p_path, -1) == '/')
             $p_path = substr($p_path, 0, strlen($p_path)-1);


### PR DESCRIPTION
Consider an archive with the following contents:

```
- folder_name
- folder_name/file_name.txt
```

Currently, `$archive->ExtractModify( 'extract_folder', 'folder_name' )` will result in the following

```
- extract_folder/folder_name
- extract_folder/file_name.txt
```

instead of 

```
- extract_folder/file_name.txt
```
