### PR TITLE
Add support for lzma2 compression.

### DIFF
--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -1921,7 +1921,7 @@ class Archive_Tar extends PEAR
                     $this->_writeBlock($v_binary_data);
                 }
 
-                @bzclose($v_temp_tar);
+                @xzclose($v_temp_tar);
             }
 
             if (!@unlink($this->_tarname.".tmp")) {


### PR DESCRIPTION
This patch adds support for lzma2 compression provided by php-xz extension https://github.com/payden/php-xz.
I copy & pasted code and changed file reading and writing methods.

I've checked mostly used methods (`listContent(), addModify(), createModify()`) with **.tar.xz files**.
They work well.

Also I can update docs and add them too.
