### PR TITLE
Fix E_STRICT errors and set minimum PHP version to 5.2.0

### DIFF
--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -762,7 +762,7 @@ class Archive_Tar extends PEAR
     // {{{ _error()
     function _error($p_message)
     {
-        $this->error_object = & $this->raiseError($p_message);
+        $this->error_object = $this->raiseError($p_message);
     }
 
     // }}}
@@ -770,7 +770,7 @@ class Archive_Tar extends PEAR
     // {{{ _warning()
     function _warning($p_message)
     {
-        $this->error_object = & $this->raiseError($p_message);
+        $this->error_object = $this->raiseError($p_message);
     }
 
     // }}}

--- a/package.xml
+++ b/package.xml
@@ -65,7 +65,7 @@ loaded. Bz2 compression is also supported with the bz2 extension loaded.</descri
  <dependencies>
   <required>
    <php>
-    <min>4.3.0</min>
+    <min>5.2.0</min>
    </php>
    <pearinstaller>
     <min>1.5.4</min>


### PR DESCRIPTION
PEAR will use PHP 5.4 as minimum in 1.10, so there is no need to keep
BC with PHP 4.3 here anymore.

The E_STRICT error was the following in two tests:

  Strict Warning: Only variables should be assigned by reference
                  in Archive/Tar.php on line 723