### PR TITLE
release of 1.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,5 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7
     - php: hhvm
 script: ./.travis.sh 

--- a/package.xml
+++ b/package.xml
@@ -31,20 +31,21 @@ loaded. Bz2 compression is also supported with the bz2 extension loaded.</descri
   <email>stig@php.net</email>
   <active>no</active>
  </helper>
- <date>2015-02-26</date>
- <time>17:07:32</time>
+ <date>2015-07-17</date>
+ <time>08:32:23</time>
  <version>
-  <release>1.3.14</release>
-  <api>1.3.1</api>
+  <release>1.4.0</release>
+  <api>1.4.0</api>
  </version>
  <stability>
   <release>stable</release>
   <api>stable</api>
  </stability>
- <license uri="http://www.opensource.org/licenses/bsd-license.php">New BSD
- License</license>
+ <license uri="http://www.opensource.org/licenses/bsd-license.php">New BSD License</license>
  <notes>
-* Fix Bug #18505: Possible incorrect handling of file names in TAR [mrook]
+* Add support for PHP 7
+* Drop support for PHP 4
+* Add visibility declarations to methods and properties
  </notes>
  <contents>
   <dir name="/">
@@ -60,7 +61,7 @@ loaded. Bz2 compression is also supported with the bz2 extension loaded.</descri
   <name>PEAR</name>
   <channel>pear.php.net</channel>
   <min>1.8.0</min>
-  <max>1.9.10</max>
+  <max>1.10.10</max>
  </compatible>
  <dependencies>
   <required>
@@ -68,12 +69,31 @@ loaded. Bz2 compression is also supported with the bz2 extension loaded.</descri
     <min>5.2.0</min>
    </php>
    <pearinstaller>
-    <min>1.5.4</min>
+    <min>1.9.0</min>
    </pearinstaller>
   </required>
  </dependencies>
  <phprelease />
  <changelog>
+
+  <release>
+   <version>
+    <release>1.4.0</release>
+    <api>1.4.0</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <date>2015-07-17</date>
+   <license uri="http://www.opensource.org/licenses/bsd-license.php">New BSD License</license>
+   <notes>
+* Add support for PHP 7
+* Drop support for PHP 4
+* Add visibility declarations to methods and properties
+   </notes>
+  </release>
+
   <release>
    <version>
     <release>1.3.13</release>


### PR DESCRIPTION
@mrook - could you please release 1.4.0 so that pear-core 1.10.0 (which brings PHP7 support) can depend on it?