### PR TITLE
Fix PEAR.php loading for Composer custom installers

### DIFF
--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -39,7 +39,11 @@
  * @link      http://pear.php.net/package/Archive_Tar
  */
 
-require_once 'PEAR.php';
+// If the PEAR class cannot be loaded via the autoloader,
+// then try to require_once it from the PHP include path.
+if (!class_exists('PEAR')) {
+    require_once 'PEAR.php';
+}
 
 define('ARCHIVE_TAR_ATT_SEPARATOR', 90001);
 define('ARCHIVE_TAR_END_BLOCK', pack("a512", ''));
@@ -139,7 +143,7 @@ class Archive_Tar extends PEAR
     public function __construct($p_tarname, $p_compress = null)
     {
         parent::__construct();
-        
+
         $this->_compress = false;
         $this->_compress_type = 'none';
         if (($p_compress === null) || ($p_compress == '')) {
@@ -238,7 +242,7 @@ class Archive_Tar extends PEAR
                    "Z32uname/Z32gname/Z8devmajor/Z8devminor/Z131prefix";
         }
 
-        
+
     }
 
     public function __destruct()


### PR DESCRIPTION
Do not try to call require_once on PEAR.php if it has already been loaded by the autoloader.

**Motivation**

The `require_once` of PEAR.php can cause a fatal error if this file is not available on the PHP include path.  When using an autoloader, such as with Composer, this file does not need to be loaded; we can avoid needlessly stopping execution simply by testing to see if the file is already available via the autoloader.

Note that for a typical Composer application, the `require` line does not cause any problems, as Archive_Tar has an `include` line in its composer.json that allows PHP to find it when requested. However, Composer custom installers cannot benefit from this, because `include` and autoload files are not available in custom installers. Inside custom installers, Archive_Tar will fail if PEAR.php is not installed on the global PHP include path.

For more information, see https://github.com/drupal-composer/drupal-project/issues/111