### PR TITLE
Remove unneeded by-reference on built-in fuction

### DIFF
--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -659,7 +659,7 @@ class Archive_Tar extends PEAR
         }
 
         // ----- Get the arguments
-        $v_att_list = & func_get_args();
+        $v_att_list = func_get_args();
 
         // ----- Read the attributes
         $i = 0;


### PR DESCRIPTION
PHP 7.2 is complaining about this. It also doesn't appear to be
needed, as the argument array items aren't being passed by-reference.