### PR TITLE
Fix dangling symlinks

### DIFF
--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -1338,13 +1338,6 @@ class Archive_Tar extends PEAR
             $p_stored_filename = $p_filename;
         }
 
-        $v_linkname = '';
-        $v_reduced_linkname = '';
-        if (@is_link($p_filename)) {
-            $v_linkname = readlink($p_filename);
-            $v_reduced_linkname = $this->_pathReduction($v_linkname);
-        }
-
         $v_reduced_filename = $this->_pathReduction($p_stored_filename);
 
         if (strlen($v_reduced_filename) > 99) {
@@ -1353,8 +1346,8 @@ class Archive_Tar extends PEAR
             }
         }
 
-        if (strlen($v_reduced_linkname) > 99) {
-            if (!$this->_writeLongHeader($v_reduced_linkname, true)) {
+        if (strlen($v_linkname) > 99) {
+            if (!$this->_writeLongHeader($v_linkname, true)) {
                 return false;
             }
         }
@@ -1407,7 +1400,7 @@ class Archive_Tar extends PEAR
         $v_binary_data_last = pack(
             "a1a100a6a2a32a32a8a8a155a12",
             $v_typeflag,
-            $v_reduced_linkname,
+            $v_linkname,
             $v_magic,
             $v_version,
             $v_uname,

--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -1346,6 +1346,11 @@ class Archive_Tar extends PEAR
             }
         }
 
+        $v_linkname = '';
+        if (@is_link($p_filename)) {
+            $v_linkname = readlink($p_filename);
+        }
+
         if (strlen($v_linkname) > 99) {
             if (!$this->_writeLongHeader($v_linkname, true)) {
                 return false;
@@ -1358,7 +1363,7 @@ class Archive_Tar extends PEAR
         $v_perms = sprintf("%07s", DecOct($v_info['mode'] & 000777));
         $v_mtime = sprintf("%011s", DecOct($v_info['mtime']));
 
-        if ($v_linkname !== '') {
+        if (@is_link($p_filename)) {
             $v_typeflag = '2';
             $v_size = sprintf("%011s", DecOct(0));
         } elseif (@is_dir($p_filename)) {


### PR DESCRIPTION
Performing path reduction on symlinks breaks relative symlinks:

1. A symlink `robo` might point to a relative path `../consolidation/robo/robo`;
2. Adding this symlink to the tar file should not change the symlink;

Since [23769](https://pear.php.net/bugs/bug.php?id=23769) the symlink is resolve to the path of the destination on the system where the tar file is created. This doesn't necessarily match the relative path intended.

This may cause bugs like this:
`chmod: cannot operate on dangling symlink ‘vendor/bin/robo’`

See https://pear.php.net/bugs/bug.php?id=23788