### PR TITLE
Improve path traversal detection for forward and backward slashes

### DIFF
--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -1770,11 +1770,8 @@ class Archive_Tar extends PEAR
         if (strpos($file, 'phar://') === 0) {
             return true;
         }
-        if (strpos($file, DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR) !== false) {
-            return true;
-        }
-        if (strpos($file, '..' . DIRECTORY_SEPARATOR) === 0) {
-            return true;
+        if (strpos($file, '../') !== false || strpos($file, '..\\') !== false) {
+                return true;
         }
         return false;
     }


### PR DESCRIPTION
Hallo Michiel,
I hope you remember our conversation with path traversal detection improvements. I thought to send a PR to see if it helps in any way. 

In Windows, both forward and backward slashes are valid as directory separators, and because the Tar archive could come from different hosts, an archive packed with forward slashes would still work in Windows although we do not reject it. 

This PR simplifies and blindly rejects path traversals in both systems. This aligns with [GNU tar's detection](https://github.com/Distrotech/tar/blob/20b55f0679d314568ec21ae6db1ea635494e292b/src/names.c#L1829).