### PR TITLE
Read files with bigger buffer to speed up archive generation process

### DIFF
--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -1257,19 +1257,19 @@ class Archive_Tar extends PEAR
                 return false;
             }
 
-	        $iLen = 1024*1024;
-	        while (($v_buffer = fread($v_file, $iLen)) != '') {
-		        $iBufferLen = strlen("$v_buffer");
-		        if ($iBufferLen != $iLen)
+	        $length = 1024*1024;
+	        while (($v_buffer = fread($v_file, $length)) != '') {
+		        $buffer_length = strlen("$v_buffer");
+		        if ($buffer_length != $length)
 		        {
-			        $iPack = ((int)($iBufferLen / 512) + 1) * 512;
-			        $sPack = sprintf('a%d', $iPack);
+			        $pack_size = ((int)($buffer_length / 512) + 1) * 512;
+			        $pack_format = sprintf('a%d', $pack_size);
 		        }
 		        else
 		        {
-			        $sPack = sprintf('a%d', $iLen);
+			        $pack_format = sprintf('a%d', $length);
 		        }
-		        $v_binary_data = pack($sPack, "$v_buffer");
+		        $v_binary_data = pack($pack_format, "$v_buffer");
 		        $this->_writeBlock($v_binary_data);
 	        }
 

--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -125,6 +125,12 @@ class Archive_Tar extends PEAR
      * @var string
      */
     public $_fmt ='';
+
+    /**
+     * @var int Length of the read buffer in bytes
+     */
+    protected $length;
+
     /**
      * Archive_Tar Class constructor. This flavour of the constructor only
      * declare a new Archive_Tar object, identifying it by the name of the
@@ -137,10 +143,11 @@ class Archive_Tar extends PEAR
      *               parameter indicates if gzip, bz2 or lzma2 compression
      *               is required.  For compatibility reason the
      *               boolean value 'true' means 'gz'.
+     * @param int $length value to set to the {@link length} attribute
      *
      * @return bool
      */
-    public function __construct($p_tarname, $p_compress = null)
+    public function __construct($p_tarname, $p_compress = null, $length = 512)
     {
         parent::__construct();
 
@@ -243,6 +250,7 @@ class Archive_Tar extends PEAR
         }
 
 
+        $this->length = $length;
     }
 
     public function __destruct()
@@ -1257,17 +1265,16 @@ class Archive_Tar extends PEAR
                 return false;
             }
 
-	        $length = 1024*1024;
-	        while (($v_buffer = fread($v_file, $length)) != '') {
+	        while (($v_buffer = fread($v_file, $this->length)) != '') {
 		        $buffer_length = strlen("$v_buffer");
-		        if ($buffer_length != $length)
+		        if ($buffer_length != $this->length)
 		        {
 			        $pack_size = ((int)($buffer_length / 512) + 1) * 512;
 			        $pack_format = sprintf('a%d', $pack_size);
 		        }
 		        else
 		        {
-			        $pack_format = sprintf('a%d', $length);
+			        $pack_format = sprintf('a%d', $this->length);
 		        }
 		        $v_binary_data = pack($pack_format, "$v_buffer");
 		        $this->_writeBlock($v_binary_data);

--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -1257,10 +1257,21 @@ class Archive_Tar extends PEAR
                 return false;
             }
 
-            while (($v_buffer = fread($v_file, 512)) != '') {
-                $v_binary_data = pack("a512", "$v_buffer");
-                $this->_writeBlock($v_binary_data);
-            }
+	        $iLen = 1024*1024;
+	        while (($v_buffer = fread($v_file, $iLen)) != '') {
+		        $iBufferLen = strlen("$v_buffer");
+		        if ($iBufferLen != $iLen)
+		        {
+			        $iPack = ((int)($iBufferLen / 512) + 1) * 512;
+			        $sPack = sprintf('a%d', $iPack);
+		        }
+		        else
+		        {
+			        $sPack = sprintf('a%d', $iLen);
+		        }
+		        $v_binary_data = pack($sPack, "$v_buffer");
+		        $this->_writeBlock($v_binary_data);
+	        }
 
             fclose($v_file);
         } else {


### PR DESCRIPTION
Hello,
Thanks for this nice lib !

We're using it in our app to generate archives for backups. As there are some large files (especially the MySQL dump) we did this little modification that improves generation time a lot.

Instead of reading each files using a 512 bytes buffer, we're using a 1024*1024 byte buffer, until the last 512 bytes of the file.