### PR TITLE
Check _temp_tarname before deleting temp file in destructor.

### DIFF
--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -257,7 +257,7 @@ class Archive_Tar extends PEAR
     {
         $this->_close();
         // ----- Look for a local copy to delete
-        if ($this->_temp_tarname != '') {
+        if ($this->_temp_tarname != '' && (bool) preg_match('/^tar[[:alnum:]]*\.tmp$/', $this->_temp_tarname)) {
             @unlink($this->_temp_tarname);
         }
     }


### PR DESCRIPTION
This is a security hardening which I believe is safe to discuss in public.

The `__destruct()` method can be abused via deserialization / object injection to delete arbitrary files.

As it looks like `_temp_tarname` is only ever set in one place:

```
    public function _openRead()
    {
        if (strtolower(substr($this->_tarname, 0, 7)) == 'http://') {

            // ----- Look if a local copy need to be done
            if ($this->_temp_tarname == '') {
                $this->_temp_tarname = uniqid('tar') . '.tmp';
```

...it seems like we should be able to check the filename before actually deleting a "temp file".

Additional checking could be done to ensure that `_tarname` matches the above etc..., but just checking `_temp_tarname` should be sufficient to avoid abuse.