### PR TITLE
fix @return true... to @return bool true... on some functions

### DIFF
--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -280,7 +280,7 @@ class Archive_Tar extends PEAR
      *              single string with names separated by a single
      *              blank space.
      *
-     * @return true on success, false on error.
+     * @return bool true on success, false on error.
      * @see    createModify()
      */
     public function create($p_filelist)
@@ -300,7 +300,7 @@ class Archive_Tar extends PEAR
      *              single string with names separated by a single
      *              blank space.
      *
-     * @return true on success, false on error.
+     * @return bool true on success, false on error.
      * @see    createModify()
      * @access public
      */
@@ -443,7 +443,7 @@ class Archive_Tar extends PEAR
      *                             each element in the list, when
      *                             relevant.
      *
-     * @return true on success, false on error.
+     * @return bool true on success, false on error.
      */
     public function addModify($p_filelist, $p_add_dir, $p_remove_dir = '')
     {
@@ -496,7 +496,7 @@ class Archive_Tar extends PEAR
      *                               gid => the group ID of the file
      *                                   (default = 0 = root)
      *
-     * @return true on success, false on error.
+     * @return bool true on success, false on error.
      */
     public function addString($p_filename, $p_string, $p_datetime = false, $p_params = array())
     {
@@ -622,7 +622,7 @@ class Archive_Tar extends PEAR
      * @param boolean $p_preserve Preserve user/group ownership of files
      * @param boolean $p_symlinks Allow symlinks.
      *
-     * @return true on success, false on error.
+     * @return bool true on success, false on error.
      * @see    extractModify()
      */
     public function extractList($p_filelist, $p_path = '', $p_remove_path = '', $p_preserve = false, $p_symlinks = true)
@@ -660,7 +660,7 @@ class Archive_Tar extends PEAR
      * list of parameters, in the format attribute code + attribute values :
      * $arch->setAttribute(ARCHIVE_TAR_ATT_SEPARATOR, ',');
      *
-     * @return true on success, false on error.
+     * @return bool true on success, false on error.
      */
     public function setAttribute()
     {


### PR DESCRIPTION
Static analysis fails because the phpdoc implies that the method always return `true`, when in fact it returns a `bool`.