### PR TITLE
Avoid returning values from __construct() and __destruct()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6' ]
         dependencies: [ 'locked' ]
 
     name: PHP ${{ matrix.php }} on ${{ matrix.operating-system }} with ${{ matrix.dependencies }} dependencies

--- a/Archive/Tar.php
+++ b/Archive/Tar.php
@@ -185,7 +185,7 @@ class Archive_Tar extends PEAR
                             "Unsupported compression type '$p_compress'\n" .
                             "Supported types are 'gz', 'bz2' and 'lzma2'.\n"
                         );
-                        return false;
+                        return;
                     }
                 }
             }
@@ -213,7 +213,7 @@ class Archive_Tar extends PEAR
                     "Please make sure your version of PHP was built " .
                     "with '$extname' support.\n"
                 );
-                return false;
+                return;
             }
         }
 


### PR DESCRIPTION
Drupal hit it using latest PHP 8.6 alpha1 pipeline

refs
- https://wiki.php.net/rfc/deprecate-return-value-from-construct
- https://github.com/php/php-src/pull/21982